### PR TITLE
feat(bot): Add help command to display available commands (#7)

### DIFF
--- a/src/StonkMarketGame.Bot/Modules/HelpModule.cs
+++ b/src/StonkMarketGame.Bot/Modules/HelpModule.cs
@@ -1,0 +1,21 @@
+using Discord.Interactions;
+using StonkMarketGame.Bot.Services;
+
+namespace StonkMarketGame.Bot.Modules;
+
+public class HelpModule : InteractionModuleBase<SocketInteractionContext>
+{
+    private readonly EmbedService _embedService;
+
+    public HelpModule(EmbedService embedService)
+    {
+        _embedService = embedService;
+    }
+
+    [SlashCommand("help", "Display available commands and their usage")]
+    public async Task Help()
+    {
+        var embed = _embedService.BuildHelp();
+        await RespondAsync(embed: embed, ephemeral: true);
+    }
+}

--- a/src/StonkMarketGame.Bot/Services/EmbedService.cs
+++ b/src/StonkMarketGame.Bot/Services/EmbedService.cs
@@ -80,4 +80,39 @@ public class EmbedService
 
         return embed.Build();
     }
+
+    public Embed BuildHelp()
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("📋 Stonk Market Game Commands")
+            .WithDescription("Welcome to the Stonk Market Game! Here are the available commands:")
+            .WithColor(new Color(0x3498DB)) // Blue
+            .WithCurrentTimestamp()
+            .WithFooter("Stonk Market Game");
+
+        embed.AddField("💹 Market Commands",
+            "`/quote <ticker>` - Get real-time stock data\n" +
+            "Example: `/quote AAPL`",
+            inline: false);
+
+        embed.AddField("💼 Portfolio Commands",
+            "`/portfolio` - View your portfolio and cash balance\n" +
+            "`/buy <ticker> <quantity>` - Buy shares of a stock\n" +
+            "`/sell <ticker> <quantity>` - Sell shares from your portfolio\n" +
+            "Example: `/buy MSFT 10`, `/sell AAPL 5`",
+            inline: false);
+
+        embed.AddField("ℹ️ Help",
+            "`/help` - Display this help message",
+            inline: false);
+
+        embed.AddField("💡 Getting Started",
+            "1. Check a stock price with `/quote`\n" +
+            "2. Buy shares with `/buy`\n" +
+            "3. Track your investments with `/portfolio`\n" +
+            "4. Sell when you're ready with `/sell`",
+            inline: false);
+
+        return embed.Build();
+    }
 }


### PR DESCRIPTION
## Summary
- Added new `/help` slash command that displays all available bot commands with usage examples
- Created HelpModule following existing module patterns
- Extended EmbedService with BuildHelp method to create formatted help embed
- Help message includes market commands, portfolio commands, and getting started guide
- Command response is ephemeral (only visible to the user who ran it)

## Test plan
- [x] Code compiles successfully
- [x] Help command displays properly formatted embed with all current commands
- [x] Message is ephemeral as intended
- [x] Follows existing code conventions and patterns

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a /help slash command that displays an in-app help panel.
  * Help panel includes organized command categories (Market, Portfolio, Help) with usage examples.
  * Provides a quick-start guide to get new users set up.
  * Responses are ephemeral to keep help visible only to the requesting user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->