### PR TITLE
fix: Configure proper UTF-8 locale in Docker container (#19)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ RUN dotnet publish src/StonkMarketGame.Bot/StonkMarketGame.Bot.csproj -c Release
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 
+# Install locales package and configure UTF-8 locale
+RUN apt-get update && \
+    apt-get install -y locales && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+
 # Copy the published application
 COPY --from=build /app/out .
 
@@ -31,6 +38,8 @@ COPY --from=build /app/src/StonkMarketGame.Bot/appsettings.json .
 
 # Set environment variables
 ENV ASPNETCORE_ENVIRONMENT=Production
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Run the application
 ENTRYPOINT ["dotnet", "StonkMarketGame.Bot.dll"]


### PR DESCRIPTION
- Install locales package and generate en_US.UTF-8 locale
- Set LANG and LC_ALL environment variables for proper locale support
- Ensures correct formatting of dates, numbers, and currency in bot output

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default locale set to en_US.UTF-8 in the runtime container, ensuring proper UTF-8 handling for international characters across logs, CLI output, and application behavior.

* **Chores**
  * Added locale packages and generated en_US.UTF-8 in the runtime image.
  * Set LANG and LC_ALL to en_US.UTF-8 for consistent environment defaults.
  * Build stage unchanged; no impact on published artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->